### PR TITLE
Change from Class to Defined Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation can be found here: http://sourceforge.net/projects/automysqlbackup
 
 ## Compatibility
 
-The module has sucessfully been tested on Ubuntu 12.04+, Debian 6.0, and CentOS 6.3. If you find it doesn't work on your platform, open up a ticket on the GitHub project page.
+The module has sucessfully been tested on Ubuntu 12.04+, Debian 6.0, and CentOS 6.4. If you find it doesn't work on your platform, open up a ticket on the GitHub project page.
 
 ## Variable Names
 
@@ -24,16 +24,19 @@ Anything with an empty string implies that you are conceding to the default valu
 
 ## Usage
 
-### Basic:
+Usage comes in two ways. You can use the following in your manifests, or you can load the backup configurating into automysqlbackup::config and automysqlbackup::config_defaults via hiera or other ENC. 
 
-    class { 'automysqlbackup':
+### Basic:
+    include automysql::backup
+    automysqlbackup::backup { "mysqlbackup":
       mysql_dump_username  => 'root',
       mysql_dump_password  => 'password',
     }
 
 ### Daily backups only excluding certain databases:
 
-    class { 'automysqlbackup':
+    include automysql::backup
+    automysqlbackup::backup { "mysqlbackup":
       mysql_dump_username => 'root',
       mysql_dump_password => 'password',
       do_monthly          => '0',
@@ -41,8 +44,13 @@ Anything with an empty string implies that you are conceding to the default valu
       db_exclude          => ['performance_schema','information_schema'],
     }
 
-### Without cron job creation:
-    class { 'automysqlbackup':
+### Without cron job creation, changes the default backup directory:
+    
+    class { "automysqlbackup":
+      backup_dir           => '/home/backups'
+    }
+
+    automysqlbackup::backup { "mysqlbackup":
       mysql_dump_username  => 'root',
       mysql_dump_password  => 'password',
       cron_script          => false,

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -81,7 +81,7 @@ define automysqlbackup::backup (
   $dryrun = ''
 ) {
   
-  require automysqlbackup
+  include automysqlbackup
   
   if $backup_dir {
     $local_backup_dir = "${backup_dir}/${name}"

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -82,20 +82,19 @@ define automysqlbackup::backup (
 ) {
   
   include automysqlbackup
-  
-  if $backup_dir {
+
+  if empty($backup_dir) {  
+    $local_backup_dir = "${automysqlbackup::backup_dir}/${name}"
+  } else {
     $local_backup_dir = "${backup_dir}/${name}"
-  } 
-  else {
-    $local_backup_dir = "${automysqlbackup::params::backup_dir}/${name}"
-  }
-  if $etc_dir {
-    $local_etc_file = "${etc_dir}/${name}.conf"
-  } 
-  else {
-    $local_etc_file = "${automysqlbackup::params::etc_dir}/${name}.conf"
   }
 
+  if empty($etc_dir) {
+    $local_etc_file = "${automysqlbackup::etc_dir}/${name}.conf"
+  } else {
+    $local_etc_file = "${etc_dir}/${name}.conf"
+  }
+  
   file { $local_backup_dir:
     ensure  => directory,
     owner   => 'root',

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -83,17 +83,17 @@ define automysqlbackup::backup (
   
   require automysqlbackup
   
-  if is_string($backup_dir) {
-    $local_backup_dir = $backup_dir
+  if $backup_dir {
+    $local_backup_dir = "${backup_dir}/${name}"
   } 
   else {
-    $local_backup_dir = $automysqlbackup::params::backup_dir
+    $local_backup_dir = "${automysqlbackup::params::backup_dir}/${name}"
   }
-  if is_string($etc_dir) {
-    $local_etc_file = "${etc_dir}/${name}"
+  if $etc_dir {
+    $local_etc_file = "${etc_dir}/${name}.conf"
   } 
   else {
-    $local_etc_file = "${automysqlbackup::params::etc_dir}/${name}"
+    $local_etc_file = "${automysqlbackup::params::etc_dir}/${name}.conf"
   }
 
   file { $local_backup_dir:
@@ -103,7 +103,7 @@ define automysqlbackup::backup (
     mode    => '0755',
   }
   if $cron_script {
-    file { '/etc/cron.daily/${name}.automysqlbackup':
+    file { "/etc/cron.daily/${name}.automysqlbackup":
       ensure   => file,
       owner    => 'root',
       group    => 'root',

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,0 +1,173 @@
+# == Class: automysqlbackup
+#
+# Puppet module to install and configure AutoMySQLBackup for periodic
+# MySQL backups.
+#
+# Before using this module, you need to consult the automysqlbackup
+# developer documentation in order to comprehend what each option
+# performs. It is included within this module and is certainly
+# worth getting familiar with.
+#
+# === Variables
+#
+# With the exception of $cron_script, I have kept the same variable
+# names as the author of the script to make it easier to lookup the
+# documentation. Essentially, add CONFIG_ to the variable in question
+# and regex search the documentation to find the meaning. No interpretation
+# from me.
+#
+# === Examples
+#
+#  class { 'automysqlbackup':
+#    mysql_dump_username => "root",
+#    mysql_dump_password => "password",
+#  }
+#
+# === Authors
+#
+# NextRevision <notarobot@nextrevision.net>
+#
+# === Copyright
+#
+# Copyright 2012 NextRevision, unless otherwise noted.
+
+
+define automysqlbackup::backup (
+  $cron_script = true,
+  $cron_set_permissions = true,
+  $mysql_dump_username = '',
+  $mysql_dump_password = '',
+  $mysql_dump_host = '',
+  $mysql_dump_port = 3306,
+  $backup_dir = '',
+  $etc_dir = '',
+  $multicore = '',
+  $multicore_threads = '',
+  $db_names = [],
+  $db_month_names = [],
+  $db_exclude = [],
+  $table_exclude = [],
+  $do_monthly = '01',
+  $do_weekly = '5',
+  $rotation_daily = '6',
+  $rotation_weekly = '35',
+  $rotation_monthly = '150',
+  $mysql_dump_commcomp = '',
+  $mysql_dump_usessl = '',
+  $mysql_dump_socket = '',
+  $mysql_dump_max_allowed_packet = '',
+  $mysql_dump_buffer_size = '',
+  $mysql_dump_single_transaction = '',
+  $mysql_dump_master_data = '',
+  $mysql_dump_full_schema = '',
+  $mysql_dump_dbstatus = '',
+  $mysql_dump_create_database = '',
+  $mysql_dump_use_separate_dirs = '',
+  $mysql_dump_compression = 'gzip',
+  $mysql_dump_latest = '',
+  $mysql_dump_latest_clean_filenames = '',
+  $mysql_dump_differential = '',
+  $mailcontent = '',
+  $mail_maxattsize = '',
+  $mail_splitandtar = '',
+  $mail_use_uuencoded_attachments = '',
+  $mail_address = '',
+  $encrypt = '',
+  $encrypt_password = '',
+  $backup_local_files = [],
+  $prebackup = '',
+  $postbackup = '',
+  $umask = '',
+  $dryrun = ''
+) {
+  
+  require automysqlbackup
+  
+  if is_string($backup_dir) {
+    $local_backup_dir = $backup_dir
+  } 
+  else {
+    $local_backup_dir = $automysqlbackup::params::backup_dir
+  }
+  if is_string($etc_dir) {
+    $local_etc_file = "${etc_dir}/${name}"
+  } 
+  else {
+    $local_etc_file = "${automysqlbackup::params::etc_dir}/${name}"
+  }
+
+  file { $local_backup_dir:
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+  }
+  if $cron_script {
+    file { '/etc/cron.daily/${name}.automysqlbackup':
+      ensure   => file,
+      owner    => 'root',
+      group    => 'root',
+      mode     => '0755',
+      content  => template('automysqlbackup/automysqlbackup.cron.erb'),
+    }
+  }
+
+  # Creating a hash, really could probably avoid doing this, but wanted to try
+  $template_string_options = {
+    'mysql_dump_username' => $mysql_dump_username,
+    'mysql_dump_password' => $mysql_dump_password,
+    'mysql_dump_host' => $mysql_dump_host,
+    'mysql_dump_port' => $mysql_dump_port,
+    'backup_dir' => $local_backup_dir,
+    'multicore' => $multicore,
+    'multicore_threads' => $multicore_threads,
+    'do_monthly' => $do_monthly,
+    'do_weekly' => $do_weekly,
+    'rotation_daily' => $rotation_daily,
+    'rotation_weekly' => $rotation_weekly,
+    'rotation_monthly' => $rotation_monthly,
+    'mysql_dump_commcomp' => $mysql_dump_commcomp,
+    'mysql_dump_usessl' => $mysql_dump_usessl,
+    'mysql_dump_socket' => $mysql_dump_socket,
+    'mysql_dump_max_allowed_packet' => $mysql_dump_max_allowed_packet,
+    'mysql_dump_buffer_size' => $mysql_dump_buffer_size,
+    'mysql_dump_single_transaction' => $mysql_dump_single_transaction,
+    'mysql_dump_master_data' => $mysql_dump_master_data,
+    'mysql_dump_full_schema' => $mysql_dump_full_schema,
+    'mysql_dump_dbstatus' => $mysql_dump_dbstatus,
+    'mysql_dump_create_database' => $mysql_dump_create_database,
+    'mysql_dump_use_separate_dirs' => $mysql_dump_use_separate_dirs,
+    'mysql_dump_compression' => $mysql_dump_compression,
+    'mysql_dump_latest' => $mysql_dump_latest,
+    'mysql_dump_latest_clean_filenames' => $mysql_dump_latest_clean_filenames,
+    'mysql_dump_differential' => $mysql_dump_differential,
+    'mailcontent' => $mailcontent,
+    'mail_maxattsize' => $mail_maxattsize,
+    'mail_splitandtar' => $mail_splitandtar,
+    'mail_use_uuencoded_attachments' => $mail_use_uuencoded_attachments,
+    'mail_address' => $mail_address,
+    'encrypt' => $encrypt,
+    'encrypt_password' => $encrypt_password,
+    'prebackup' => $prebackup,
+    'postbackup' => $postbackup,
+    'umask' => $umask,
+    'dryrun' => $dryrun
+  }
+
+  $template_array_options = {
+    'db_names' => $db_names,
+    'db_month_names' => $db_month_names,
+    'db_exclude' => $db_exclude,
+    'table_exclude' => $table_exclude,
+    'backup_local_files' => $backup_local_files,
+  }
+
+  # last but not least, create the automysqlbackup.conf
+  file { $local_etc_file:
+    ensure  => file,
+    content => template('automysqlbackup/automysqlbackup.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0650',
+  }
+}

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -40,6 +40,10 @@ define automysqlbackup::backup (
   $mysql_dump_host = '',
   $mysql_dump_port = 3306,
   $backup_dir = '',
+  $backup_dir_owner = 'root',
+  $backup_dir_group = 'root',
+  $backup_dir_perms = '0700',
+  $backup_file_perms = '0400',
   $etc_dir = '',
   $multicore = '',
   $multicore_threads = '',
@@ -94,7 +98,7 @@ define automysqlbackup::backup (
   } else {
     $local_etc_file = "${etc_dir}/${name}.conf"
   }
-  
+ 
   file { $local_backup_dir:
     ensure  => directory,
     owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,7 @@ class automysqlbackup (
   }
   if ! has_key($config_defaults,'etc_dir') {
       $config_defaults['etc_dir'] = $automysqlbackup::params::etc_dir
+  }
 
   # if you'd like to keep your config in hiera and pass it to this class.
   if is_hash($config) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class automysqlbackup (
   $bin_dir = $automysqlbackup::params::bin_dir,
   $etc_dir = $automysqlbackup::params::etc_dir,
   $backup_dir = $automysqlbackup::params::backup_dir,
-  $install_multicore,
+  $install_multicore = undef,
   $config = {},
   $config_defaults = {}
 ) inherits automysqlbackup::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class automysqlbackup (
   }
 
   # if you'd like to keep your config in hiera and pass it to this class.
-  if is_hash($config) {
+  if ! empty($config) {
     create_resources("@${module_name}::backup",$config,$config_defaults)
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,9 @@
 # and regex search the documentation to find the meaning. No interpretation
 # from me.
 #
+# $install_multicore if set to true will install pigz and pbzip2 for 
+# multicore compression. Assumes packages are available. 
+#
 # === Examples
 #
 #  class { 'automysqlbackup':
@@ -36,10 +39,10 @@ class automysqlbackup (
   $bin_dir = $automysqlbackup::params::bin_dir,
   $etc_dir = $automysqlbackup::params::etc_dir,
   $backup_dir = $automysqlbackup::params::backup_dir,
+  $install_multicore,
   $config = {},
   $config_defaults = {}
 ) inherits automysqlbackup::params {
-  
 
   file { $automysqlbackup::params::etc_dir:
     ensure  => directory,
@@ -85,4 +88,11 @@ class automysqlbackup (
   if ! empty($config) {
     create_resources('automysqlbackup::backup',$config,$config_defaults)
   }
+  
+  if $install_multicore { 
+    package { ['pigz', 'pbzip2']:
+      ensure => installed
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,15 +81,8 @@ class automysqlbackup (
     mode    => '0755',
   }
 
-  if ! has_key($config_defaults,'backup_dir') {
-      $config_defaults['backup_dir'] = $automysqlbackup::params::backup_dir
-  }
-  if ! has_key($config_defaults,'etc_dir') {
-      $config_defaults['etc_dir'] = $automysqlbackup::params::etc_dir
-  }
-
   # if you'd like to keep your config in hiera and pass it to this class.
   if ! empty($config) {
-    create_resources("@${module_name}::backup",$config,$config_defaults)
+    create_resources('automysqlbackup::backup',$config,$config_defaults)
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,5 @@
 class automysqlbackup::params {
   $bin_dir = '/usr/local/bin'
-  $etc_dir = '/etc/automysqlbackup'
+  $etc_dir = '/etc/automysqlbackup',
+  $backup_dir = '/var/backup'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class automysqlbackup::params {
   $bin_dir = '/usr/local/bin'
-  $etc_dir = '/etc/automysqlbackup',
+  $etc_dir = '/etc/automysqlbackup'
   $backup_dir = '/var/backup'
 }

--- a/templates/automysqlbackup.cron.erb
+++ b/templates/automysqlbackup.cron.erb
@@ -3,7 +3,7 @@
 BIN_FILE=/usr/local/bin/automysqlbackup
 
 if `test -x $BIN_FILE`; then
-	$BIN_FILE
+	$BIN_FILE <%= @local_etc_file %>
 	<% if cron_set_permissions %>
 	chown -R root.root <%= backup_dir %>
 	find <%= backup_dir %>/* -type f -exec chmod 400 {} \;

--- a/templates/automysqlbackup.cron.erb
+++ b/templates/automysqlbackup.cron.erb
@@ -5,9 +5,9 @@ BIN_FILE=/usr/local/bin/automysqlbackup
 if `test -x $BIN_FILE`; then
 	$BIN_FILE <%= @local_etc_file %>
 	<% if cron_set_permissions %>
-	chown -R root.root <%= backup_dir %>
-	find <%= backup_dir %>/* -type f -exec chmod 400 {} \;
-	find <%= backup_dir %>/* -type d -exec chmod 700 {} \;
+	chown -R root.root <%= @backup_dir %>
+	find <%= @backup_dir %>/* -type f -exec chmod 400 {} \;
+	find <%= @backup_dir %>/* -type d -exec chmod 700 {} \;
 	<% end %>
 else
 	echo "ERROR: File does not exist or `whoami` does not have permission to execute it."

--- a/templates/automysqlbackup.cron.erb
+++ b/templates/automysqlbackup.cron.erb
@@ -5,9 +5,9 @@ BIN_FILE=/usr/local/bin/automysqlbackup
 if `test -x $BIN_FILE`; then
 	$BIN_FILE <%= @local_etc_file %>
 	<% if cron_set_permissions %>
-	chown -R root.root <%= @backup_dir %>
-	find <%= @local_backup_dir %>/* -type f -exec chmod 400 {} \;
-	find <%= @local_backup_dir %>/* -type d -exec chmod 700 {} \;
+	chown -R <%= @backup_dir_owner -%>:<%= @backup_dir_group -%> <%= @local_backup_dir %>
+	find <%= @local_backup_dir %>/* -type f -exec chmod <%= @backup_file_perms -%> {} \;
+	find <%= @local_backup_dir %>/* -type d -exec chmod <%= @backup_dir_perms -%> {} \;
 	<% end %>
 else
 	echo "ERROR: File does not exist or `whoami` does not have permission to execute it."

--- a/templates/automysqlbackup.cron.erb
+++ b/templates/automysqlbackup.cron.erb
@@ -6,8 +6,8 @@ if `test -x $BIN_FILE`; then
 	$BIN_FILE <%= @local_etc_file %>
 	<% if cron_set_permissions %>
 	chown -R root.root <%= @backup_dir %>
-	find <%= @backup_dir %>/* -type f -exec chmod 400 {} \;
-	find <%= @backup_dir %>/* -type d -exec chmod 700 {} \;
+	find <%= @local_backup_dir %>/* -type f -exec chmod 400 {} \;
+	find <%= @local_backup_dir %>/* -type d -exec chmod 700 {} \;
 	<% end %>
 else
 	echo "ERROR: File does not exist or `whoami` does not have permission to execute it."


### PR DESCRIPTION
Hi Dude. I kinda changed all the things for the feature to create multiple backups on a single server. I tried to make so it was sane for all use cases, but I usually mess up for one or another. 

This should let you use the class to install the script, create the /etc/ and /var/backup directories and example files. Then each instance of automysqlbackup::backup will create a new configuration file and cron job. It also lets you pass automysqlbackup::config as a hash of hashes from hiera to create all those instances via a ENC. I've tested it on CentOS 6.4 and Puppet 3.2.2. 

This is not backwards compatible to any users of your module. Please point out anything dumb I did. 
