### PR TITLE
Fix cron.daily file name so it runs.

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -125,7 +125,7 @@ define automysqlbackup::backup (
   }
 
   if $cron_script {
-    file { "/etc/cron.daily/${name}.automysqlbackup":
+    file { "/etc/cron.daily/${name}-automysqlbackup":
       ensure  => file,
       owner   => 'root',
       group   => 'root',


### PR DESCRIPTION
To quote the run-parts manpage.

```
       run-parts  runs  all  the  executable  files  named  within constraints
       described below, found in directory directory.  Other files and  direc‐
       tories are silently ignored.

       If neither the --lsbsysinit option nor the --regex option is given then
       the names must consist entirely of ASCII upper- and lower-case letters,
       ASCII digits, ASCII underscores, and ASCII minus-hyphens.
```
