### PR TITLE
Empty arrays fix

### DIFF
--- a/templates/automysqlbackup.conf.erb
+++ b/templates/automysqlbackup.conf.erb
@@ -6,11 +6,14 @@
 
 # String options
 <% @template_string_options.sort.map do |k, v| -%>
-<% if !v.empty? -%>
+
 <% if v.kind_of?(Array) -%>
+<% if !v.empty? -%>
 CONFIG_<%= k %>=( '<%= v.flatten.join("' '") %>' )
+<% end -%>
 <% else -%>
 CONFIG_<%= k %>='<%= v %>'
+
 <% end -%>
 <% end -%>
-<% end -%>
+


### PR DESCRIPTION
Empty db_names configuration which should print () or nothing actually writes ('') resulting in no databases to get backed up
